### PR TITLE
Send chat data source names via names payload

### DIFF
--- a/src/tests/test_chat_tool.py
+++ b/src/tests/test_chat_tool.py
@@ -9,8 +9,8 @@ from tools.chat import codebase_consultant
 
 @pytest.mark.asyncio
 @patch('tools.chat.get_api_key_from_context')
-async def test_consultant_with_simple_ids(mock_get_api_key):
-    """Test codebase consultant with simple string IDs."""
+async def test_consultant_with_simple_names(mock_get_api_key):
+    """Test codebase consultant with simple string names."""
     mock_get_api_key.return_value = "test_key"
 
     ctx = MagicMock(spec=Context)
@@ -39,7 +39,7 @@ async def test_consultant_with_simple_ids(mock_get_api_key):
 
     ctx.request_context.lifespan_context = mock_codealive_context
 
-    # Test with simple string IDs
+    # Test with simple string names
     result = await codebase_consultant(
         ctx=ctx,
         question="Test question",
@@ -50,10 +50,10 @@ async def test_consultant_with_simple_ids(mock_get_api_key):
     call_args = mock_client.post.call_args
     request_data = call_args.kwargs["json"]
 
-    # Should convert simple IDs to {"id": "..."} format
-    assert request_data["dataSources"] == [
-        {"id": "repo123"},
-        {"id": "repo456"}
+    # Should convert simple names to the backend names array
+    assert request_data["names"] == [
+        "repo123",
+        "repo456"
     ]
 
     assert result == "Hello world"
@@ -61,8 +61,8 @@ async def test_consultant_with_simple_ids(mock_get_api_key):
 
 @pytest.mark.asyncio
 @patch('tools.chat.get_api_key_from_context')
-async def test_consultant_preserves_string_ids(mock_get_api_key):
-    """Test codebase consultant preserves string IDs."""
+async def test_consultant_preserves_string_names(mock_get_api_key):
+    """Test codebase consultant preserves string names."""
     mock_get_api_key.return_value = "test_key"
 
     ctx = MagicMock(spec=Context)
@@ -88,7 +88,7 @@ async def test_consultant_preserves_string_ids(mock_get_api_key):
 
     ctx.request_context.lifespan_context = mock_codealive_context
 
-    # Test with string IDs
+    # Test with string names
     result = await codebase_consultant(
         ctx=ctx,
         question="Test",
@@ -98,10 +98,10 @@ async def test_consultant_preserves_string_ids(mock_get_api_key):
     call_args = mock_client.post.call_args
     request_data = call_args.kwargs["json"]
 
-    # Should extract just the ID
-    assert request_data["dataSources"] == [
-        {"id": "repo123"},
-        {"id": "repo456"}
+    # Should extract just the normalized names
+    assert request_data["names"] == [
+        "repo123",
+        "repo456"
     ]
 
     assert result == "Response"
@@ -145,8 +145,8 @@ async def test_consultant_with_conversation_id(mock_get_api_key):
 
     # Should include conversation ID
     assert request_data["conversationId"] == "conv_123"
-    # Should not have data sources when continuing conversation
-    assert "dataSources" not in request_data
+    # Should not have explicit names when continuing conversation
+    assert "names" not in request_data
 
     assert result == "Continued"
 

--- a/src/tests/test_error_handling.py
+++ b/src/tests/test_error_handling.py
@@ -3,7 +3,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 import httpx
-from utils.errors import handle_api_error, format_data_source_ids
+from utils.errors import handle_api_error, format_data_source_names
 
 
 @pytest.mark.asyncio
@@ -109,36 +109,29 @@ async def test_handle_unknown_http_error():
     assert len(result) < 300
 
 
-def test_format_data_source_ids_strings():
-    """Test formatting simple string IDs."""
+def test_format_data_source_names_strings():
+    """Test formatting simple string names."""
     input_data = ["id1", "id2", "id3"]
-    result = format_data_source_ids(input_data)
+    result = format_data_source_names(input_data)
 
-    assert result == [
-        {"id": "id1"},
-        {"id": "id2"},
-        {"id": "id3"}
-    ]
+    assert result == ["id1", "id2", "id3"]
 
 
-def test_format_data_source_ids_dicts():
-    """Test formatting dictionary IDs."""
+def test_format_data_source_names_dicts():
+    """Test formatting dictionary inputs."""
     input_data = [
         {"id": "id1"},
         {"type": "repository", "id": "id2"},
+        {"name": "repo-name"},
         {"id": "id3", "extra": "field"}
     ]
-    result = format_data_source_ids(input_data)
+    result = format_data_source_names(input_data)
 
-    assert result == [
-        {"id": "id1"},
-        {"id": "id2"},
-        {"id": "id3"}
-    ]
+    assert result == ["id1", "id2", "repo-name", "id3"]
 
 
-def test_format_data_source_ids_mixed():
-    """Test formatting mixed format IDs."""
+def test_format_data_source_names_mixed():
+    """Test formatting mixed format inputs."""
     input_data = [
         "id1",
         {"id": "id2"},
@@ -146,20 +139,17 @@ def test_format_data_source_ids_mixed():
         "",  # Empty string - should be skipped
         None,  # None - should be skipped
         {"no_id": "field"},  # Missing id - should be skipped
+        {"name": "repo-name"},
         "id4"
     ]
-    result = format_data_source_ids(input_data)
+    result = format_data_source_names(input_data)
 
-    assert result == [
-        {"id": "id1"},
-        {"id": "id2"},
-        {"id": "id3"},
-        {"id": "id4"}
-    ]
+    assert result == ["id1", "id2", "id3", "repo-name", "id4"]
 
 
-def test_format_data_source_ids_empty():
+def test_format_data_source_names_empty():
     """Test formatting empty/None inputs."""
-    assert format_data_source_ids(None) == []
-    assert format_data_source_ids([]) == []
-    assert format_data_source_ids([None, "", {}]) == []
+    assert format_data_source_names(None) == []
+    assert format_data_source_names([]) == []
+    assert format_data_source_names([None, "", {}]) == []
+

--- a/src/tests/test_response_transformer.py
+++ b/src/tests/test_response_transformer.py
@@ -323,7 +323,7 @@ class TestXMLTransformer:
                         "range": {"start": {"line": 18}, "end": {"line": 168}}
                     },
                     "score": 0.99,
-                    "content": "async def codebase_search(\n    ctx: Context,\n    query: str,\n    data_source_ids: Optional[List[str]] = None,\n    mode: str = \"auto\",\n    include_content: bool = False\n) -> Dict:",
+                    "content": "async def codebase_search(\n    ctx: Context,\n    query: str,\n    data_sources: Optional[List[str]] = None,\n    mode: str = \"auto\",\n    include_content: bool = False\n) -> Dict:",
                     "dataSource": {
                         "type": "repository",
                         "id": "685b21230e3822f4efa9d073",

--- a/src/tests/test_search_tool.py
+++ b/src/tests/test_search_tool.py
@@ -51,7 +51,7 @@ async def test_codebase_search_returns_xml_string(mock_get_api_key):
     result = await codebase_search(
         ctx=ctx,
         query="authenticate_user",
-        data_source_ids=["test_id"],
+        data_sources=["test-name"],
         mode="auto",
         include_content=False
     )
@@ -62,6 +62,11 @@ async def test_codebase_search_returns_xml_string(mock_get_api_key):
     # Verify it contains expected XML structure
     assert "<results>" in result, "Should contain results tag"
     assert "<search_result" in result, "Should contain search_result tag"
+
+    # Verify the request used the Names query parameter
+    call_args = mock_client.get.call_args
+    params = call_args.kwargs["params"]
+    assert ("Names", "test-name") in params
 
 
 @pytest.mark.asyncio
@@ -82,7 +87,7 @@ async def test_codebase_search_empty_query_returns_error_string():
     result = await codebase_search(
         ctx=ctx,
         query="",
-        data_source_ids=["test_id"],
+        data_sources=["test-name"],
         mode="auto",
         include_content=False
     )
@@ -138,7 +143,7 @@ async def test_codebase_search_api_error_returns_error_string(mock_get_api_key):
     result = await codebase_search(
         ctx=ctx,
         query="test query",
-        data_source_ids=["invalid_id"],
+        data_sources=["invalid-name"],
         mode="auto",
         include_content=False
     )

--- a/src/tools/datasources.py
+++ b/src/tools/datasources.py
@@ -25,6 +25,7 @@ async def get_data_sources(ctx: Context, alive_only: bool = True) -> str:
         A formatted list of available data sources with the following information for each:
         - id: Unique identifier for the data source, used in other API calls
         - name: Human-readable name of the repository or workspace
+        - description: Summary of the codebase contents to guide search and chat usage
         - type: The type of data source ("Repository" or "Workspace")
         - url: URL of the repository (for Repository type only)
         - repositoryIds: List of repository IDs included in the workspace (for Workspace type only)
@@ -48,7 +49,7 @@ async def get_data_sources(ctx: Context, alive_only: bool = True) -> str:
         For workspaces, the repositoryIds can be used to identify and work with
         individual repositories that make up the workspace.
 
-        Use the returned data source IDs with the codebase_search and codebase_consultant functions.
+        Use the returned data source names with the codebase_search and codebase_consultant functions.
     """
     context: CodeAliveContext = ctx.request_context.lifespan_context
 
@@ -84,7 +85,7 @@ async def get_data_sources(ctx: Context, alive_only: bool = True) -> str:
         result = f"Available data sources:\n{formatted_data}"
 
         # Add usage hint
-        result += "\n\nYou can use these data source IDs with the codebase_search and codebase_consultant functions."
+        result += "\n\nYou can use these data source names with the codebase_search and codebase_consultant functions."
 
         return result
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,11 +1,19 @@
 """Utility functions for CodeAlive MCP server."""
 
 from .response_transformer import transform_search_response_to_xml
-from .errors import handle_api_error, format_data_source_ids, normalize_data_source_ids
+from .errors import (
+    handle_api_error,
+    format_data_source_names,
+    normalize_data_source_names,
+    format_data_source_ids,
+    normalize_data_source_ids,
+)
 
 __all__ = [
     'transform_search_response_to_xml',
     'handle_api_error',
+    'format_data_source_names',
+    'normalize_data_source_names',
     'format_data_source_ids',
     'normalize_data_source_ids'
 ]

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -51,82 +51,67 @@ async def handle_api_error(
         return f"Error: {error_msg}. Please check your input parameters and try again."
 
 
-def normalize_data_source_ids(data_sources) -> list:
-    """
-    Normalize data source IDs from various Claude Desktop serialization formats.
-
-    Handles:
-    - Proper arrays: ["id1", "id2"]
-    - JSON-encoded strings: "[\"id1\", \"id2\"]"
-    - Plain strings: "id1"
-    - None/empty values
-
-    Args:
-        data_sources: Data sources in any format from Claude Desktop
-
-    Returns:
-        List of string IDs: ["id1", "id2"]
-    """
+def normalize_data_source_names(data_sources) -> list:
+    """Normalize data source names from various serialization formats."""
     import json
 
     if not data_sources:
         return []
 
-    # Handle string inputs (Claude Desktop serialization issue)
     if isinstance(data_sources, str):
-        # Handle JSON-encoded string
-        if data_sources.startswith('['):
+        stripped = data_sources.strip()
+        if stripped.startswith('['):
             try:
-                data_sources = json.loads(data_sources)
+                data_sources = json.loads(stripped)
             except json.JSONDecodeError:
-                # If parsing fails, treat as single ID
                 return [data_sources]
         else:
-            # Single ID as string
             return [data_sources]
 
-    # Handle non-list types
     if not isinstance(data_sources, list):
         return [str(data_sources)]
 
-    # Already a list - extract string IDs
     result = []
     for ds in data_sources:
         if isinstance(ds, str):
             result.append(ds)
-        elif isinstance(ds, dict) and ds.get("id"):
-            result.append(ds["id"])
+        elif isinstance(ds, dict):
+            if ds.get("name"):
+                result.append(ds["name"])
+            elif ds.get("id"):
+                # Backward compatibility with legacy ID payloads
+                result.append(ds["id"])
 
     return result
 
 
-def format_data_source_ids(data_sources: Optional[list]) -> list:
-    """
-    Convert various data source formats to the API's expected format.
-
-    Handles:
-    - Simple string IDs: ["id1", "id2"]
-    - Dict format: [{"id": "id1"}, {"type": "repository", "id": "id2"}]
-    - Mixed formats
-    - None/empty values
-
-    Args:
-        data_sources: List of data sources in various formats
-
-    Returns:
-        List of dicts with 'id' field: [{"id": "id1"}, {"id": "id2"}]
-    """
+def format_data_source_names(data_sources: Optional[list]) -> list:
+    """Convert various data source inputs to a simple list of data source names."""
     if not data_sources:
         return []
 
-    formatted = []
+    formatted: list[str] = []
+
     for ds in data_sources:
-        if isinstance(ds, str) and ds:
-            # Simple string ID
-            formatted.append({"id": ds})
-        elif isinstance(ds, dict) and ds.get("id"):
-            # Already has id field - extract just the id
-            formatted.append({"id": ds["id"]})
-        # Skip None/empty values
+        if isinstance(ds, str):
+            name = ds.strip()
+            if name:
+                formatted.append(name)
+        elif isinstance(ds, dict):
+            name = ds.get("name") or ds.get("id")
+            if isinstance(name, str):
+                name = name.strip()
+                if name:
+                    formatted.append(name)
+            elif name is not None:
+                formatted.append(str(name))
+        elif ds is not None:
+            # Fallback: cast other primitive types to string
+            formatted.append(str(ds))
 
     return formatted
+
+
+# Backward compatibility aliases for legacy imports
+normalize_data_source_ids = normalize_data_source_names
+format_data_source_ids = format_data_source_names


### PR DESCRIPTION
## Summary
- switch the consultant request payload to populate the new `names` field instead of `dataSources`
- simplify `format_data_source_names` to return plain name strings and refresh related unit tests

## Testing
- uv run pytest *(fails: unable to reach pypi.org/fastmcp)*

------
https://chatgpt.com/codex/tasks/task_e_68eff26921a0832ba5f07cdb3d1e3f9a