### PR TITLE
Add semantic_search and grep_search MCP tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ This is a Model Context Protocol (MCP) server that provides AI clients with acce
 ### Core Components
 
 - **`codealive_mcp_server.py`**: Main entry point — bootstraps logging, tracing, registers tools and middleware
-- **Five tools**: `get_data_sources`, `codebase_search`, `fetch_artifacts`, `codebase_consultant`, `get_artifact_relationships`
+- **Eight tools**: `get_data_sources`, `semantic_search`, `grep_search`, `fetch_artifacts`, `get_artifact_relationships`, `chat`, `codebase_search`, `codebase_consultant`
 - **`core/client.py`**: `CodeAliveContext` dataclass + `codealive_lifespan` (httpx.AsyncClient lifecycle, `_server_ready` flag)
 - **`core/logging.py`**: loguru structured JSON logging + PII masking + OTel context injection
 - **`core/observability.py`**: OpenTelemetry TracerProvider setup with OTLP export
@@ -105,7 +105,7 @@ This is a Model Context Protocol (MCP) server that provides AI clients with acce
 
 1. **FastMCP Framework**: Uses FastMCP 3.x with lifespan context, middleware hooks, and built-in `Client` for testing
 2. **HTTP Client Management**: Single persistent `httpx.AsyncClient` with connection pooling, created in lifespan
-3. **Streaming Support**: `codebase_consultant` uses SSE streaming (`response.aiter_lines()`) for chat completions
+3. **Streaming Support**: `chat` and the deprecated `codebase_consultant` alias use SSE streaming (`response.aiter_lines()`) for chat completions
 4. **Environment Configuration**: Supports both .env files and command-line arguments with precedence
 5. **Error Handling**: Centralized in `utils/errors.py` — all tools use `handle_api_error()` with `method=` prefix
 6. **N8N Middleware**: Strips extra parameters (sessionId, action, chatInput, toolCallId) from n8n tool calls before validation
@@ -114,7 +114,7 @@ This is a Model Context Protocol (MCP) server that provides AI clients with acce
 ### Data Flow
 
 1. AI client connects to MCP server via stdio/HTTP transport
-2. Client calls tools (`get_data_sources` → `codebase_search` → `fetch_artifacts` / `codebase_consultant`)
+2. Client calls tools (`get_data_sources` → `semantic_search` / `grep_search` → `fetch_artifacts` / `get_artifact_relationships` → `chat` only if synthesis is still needed)
 3. Middleware chain runs: N8N cleanup → ObservabilityMiddleware (OTel span + log correlation)
 4. Tool translates MCP call to CodeAlive API request (with `X-CodeAlive-*` headers)
 5. Response parsed, formatted as XML or text, returned to AI client
@@ -144,7 +144,7 @@ The server is designed to integrate with:
 - Any MCP-compatible AI client
 
 Key integration considerations:
-- AI clients should use `get_data_sources` first to discover available repositories/workspaces, then use those IDs for targeted search and chat operations
+- AI clients should use `get_data_sources` first to discover available repositories/workspaces, then default to `semantic_search` and `grep_search` for evidence gathering; use `chat` only as a slower synthesis fallback
 - **n8n Integration**: The server includes middleware to automatically strip n8n's extra parameters (sessionId, action, chatInput, toolCallId) from tool calls, so n8n works out of the box without any special configuration
 
 ## Logging Best Practices
@@ -157,7 +157,7 @@ This project uses **loguru** for structured JSON logging. All logs go to **stder
 
 2. **All logs go to stderr.** The stdio MCP transport uses stdout for protocol messages. Any stray `print()` or stdout write will corrupt the MCP protocol and break the client. If you add a new log sink, it must target `sys.stderr`.
 
-3. **Never call `response.text` without a debug guard.** `log_api_response()` is protected by `_is_debug_enabled()` because reading `response.text` consumes the response body. The `codebase_consultant` tool streams SSE via `response.aiter_lines()` — calling `.text` first would silently consume the stream and produce empty results. If you add new response logging, always check `_is_debug_enabled()` first:
+3. **Never call `response.text` without a debug guard.** `log_api_response()` is protected by `_is_debug_enabled()` because reading `response.text` consumes the response body. The `chat` tool and deprecated `codebase_consultant` alias stream SSE via `response.aiter_lines()` — calling `.text` first would silently consume the stream and produce empty results. If you add new response logging, always check `_is_debug_enabled()` first:
    ```python
    if not _is_debug_enabled():
        return  # Do NOT touch response body at INFO level
@@ -269,7 +269,7 @@ Key points:
 - Custom lifespan yields a real `CodeAliveContext` with a mock-backed httpx client
 - `monkeypatch.setenv("CODEALIVE_API_KEY", ...)` for `get_api_key_from_context` fallback
 - Use `raise_on_error=False` when testing error paths, then assert on `result.content[0].text`
-- For SSE streaming (codebase_consultant), return `httpx.Response(200, text=sse_body)` — `aiter_lines()` works on buffered responses
+- For SSE streaming (`chat` / `codebase_consultant`), return `httpx.Response(200, text=sse_body)` — `aiter_lines()` works on buffered responses
 
 ### Unit Test Patterns
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,20 @@ It allows AI-Coding Agents to:
 Once connected, you'll have access to these powerful tools:
 
 1. **`get_data_sources`** - List your indexed repositories and workspaces
-2. **`codebase_search`** - Semantic code search across your indexed codebase (main/master branch)  
-3. **`codebase_consultant`** - AI consultant with full project expertise
+2. **`semantic_search`** - Canonical semantic search across indexed artifacts
+3. **`grep_search`** - Exact text or regex search with line-level matches
+4. **`fetch_artifacts`** - Load the full source for relevant search hits
+5. **`get_artifact_relationships`** - Expand call graph, inheritance, and reference relationships for one artifact
+6. **`codebase_consultant`** - AI consultant with full project expertise
+7. **`codebase_search`** - Deprecated legacy semantic search alias kept for backward compatibility
 
 ## 🎯 Usage Examples
 
 After setup, try these commands with your AI assistant:
 
 - *"Show me all available repositories"* → Uses `get_data_sources`
-- *"Find authentication code in the user service"* → Uses `codebase_search`
+- *"Find authentication code in the user service"* → Uses `semantic_search`
+- *"Find the exact regex that matches JWT tokens"* → Uses `grep_search`
 - *"Explain how the payment flow works in this codebase"* → Uses `codebase_consultant`
 
 ## 📚 Agent Skill
@@ -798,9 +803,12 @@ See [JetBrains MCP Documentation](https://www.jetbrains.com/help/ai-assistant/mc
    ```
 
 3. The server automatically handles n8n's extra parameters (sessionId, action, chatInput, toolCallId)
-4. Use the three available tools:
+4. Use the available tools:
    - `get_data_sources` - List available repositories
-   - `codebase_search` - Search code semantically
+   - `semantic_search` - Search code semantically
+   - `grep_search` - Search by exact text or regex
+   - `get_artifact_relationships` - Expand relationships for one artifact
+   - `codebase_search` - Legacy semantic search alias
    - `codebase_consultant` - Ask questions about code
 
 **Example Workflow:**

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Once connected, you'll have access to these powerful tools:
 3. **`grep_search`** - Exact text or regex search with line-level matches
 4. **`fetch_artifacts`** - Load the full source for relevant search hits
 5. **`get_artifact_relationships`** - Expand call graph, inheritance, and reference relationships for one artifact
-6. **`codebase_consultant`** - AI consultant with full project expertise
+6. **`chat`** - Slower synthesized codebase Q&A, typically only after search
 7. **`codebase_search`** - Deprecated legacy semantic search alias kept for backward compatibility
+8. **`codebase_consultant`** - Deprecated alias for `chat`
 
 ## 🎯 Usage Examples
 
@@ -40,7 +41,9 @@ After setup, try these commands with your AI assistant:
 - *"Show me all available repositories"* → Uses `get_data_sources`
 - *"Find authentication code in the user service"* → Uses `semantic_search`
 - *"Find the exact regex that matches JWT tokens"* → Uses `grep_search`
-- *"Explain how the payment flow works in this codebase"* → Uses `codebase_consultant`
+- *"Explain how the payment flow works in this codebase"* → Usually starts with `semantic_search`/`grep_search`, then optionally uses `chat`
+
+`semantic_search` and `grep_search` should be the default tools for most agents. `chat` is a slower synthesis fallback, can take up to 30 seconds, and is usually unnecessary when an agent can run a multi-step workflow with search, fetch, relationships, and local file reads. If your agent supports subagents, the highest-confidence path is to delegate a focused subagent that orchestrates `semantic_search` and `grep_search` first.
 
 ## 📚 Agent Skill
 
@@ -808,8 +811,9 @@ See [JetBrains MCP Documentation](https://www.jetbrains.com/help/ai-assistant/mc
    - `semantic_search` - Search code semantically
    - `grep_search` - Search by exact text or regex
    - `get_artifact_relationships` - Expand relationships for one artifact
+   - `chat` - Slower synthesized codebase Q&A, usually after search
    - `codebase_search` - Legacy semantic search alias
-   - `codebase_consultant` - Ask questions about code
+   - `codebase_consultant` - Deprecated alias for `chat`
 
 **Example Workflow:**
 ```

--- a/manifest.json
+++ b/manifest.json
@@ -66,12 +66,16 @@
       "description": "Search indexed artifacts by exact text or regex and return line-level matches."
     },
     {
+      "name": "chat",
+      "description": "Synthesized codebase Q&A. Slower and usually not the default choice; prefer semantic_search and grep_search first. Can take up to 30 seconds."
+    },
+    {
       "name": "fetch_artifacts",
       "description": "Fetch full source for specific search results when you need the underlying code."
     },
     {
       "name": "codebase_consultant",
-      "description": "Ask architecture and implementation questions with full codebase context."
+      "description": "Deprecated alias for chat kept for backward compatibility."
     },
     {
       "name": "get_artifact_relationships",

--- a/manifest.json
+++ b/manifest.json
@@ -55,7 +55,15 @@
     },
     {
       "name": "codebase_search",
-      "description": "Search indexed code semantically across repositories and workspaces."
+      "description": "Deprecated legacy semantic search tool kept for backward compatibility."
+    },
+    {
+      "name": "semantic_search",
+      "description": "Search indexed artifacts semantically across repositories and workspaces."
+    },
+    {
+      "name": "grep_search",
+      "description": "Search indexed artifacts by exact text or regex and return line-level matches."
     },
     {
       "name": "fetch_artifacts",

--- a/server.json
+++ b/server.json
@@ -56,7 +56,15 @@
       },
       {
         "name": "codebase_search",
-        "description": "Search across your entire codebase using natural language queries. Find functions, classes, patterns, and implementations with semantic understanding that goes beyond simple text matching."
+        "description": "Deprecated legacy semantic search tool retained for backward compatibility."
+      },
+      {
+        "name": "semantic_search",
+        "description": "Search across indexed artifacts using natural language queries and semantic retrieval."
+      },
+      {
+        "name": "grep_search",
+        "description": "Search indexed artifacts using exact text or regex patterns and return line-level matches."
       },
       {
         "name": "codebase_consultant",

--- a/server.json
+++ b/server.json
@@ -67,8 +67,12 @@
         "description": "Search indexed artifacts using exact text or regex patterns and return line-level matches."
       },
       {
+        "name": "chat",
+        "description": "Synthesized codebase Q&A. Use only after semantic_search and grep_search when you need a slower, up-to-30-second answer."
+      },
+      {
         "name": "codebase_consultant",
-        "description": "Get comprehensive AI-powered analysis, explanations, and insights about your codebase. Ask complex questions about architecture, patterns, dependencies, and implementation details."
+        "description": "Deprecated alias for chat retained for backward compatibility."
       },
       {
         "name": "fetch_artifacts",

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -133,7 +133,15 @@ class SmokeTest:
             result = await self.session.list_tools()
             tools = result.tools
 
-            expected_tools = {"codebase_consultant", "get_data_sources", "codebase_search", "fetch_artifacts", "get_artifact_relationships"}
+            expected_tools = {
+                "codebase_consultant",
+                "codebase_search",
+                "fetch_artifacts",
+                "get_artifact_relationships",
+                "get_data_sources",
+                "grep_search",
+                "semantic_search",
+            }
             actual_tools = {tool.name for tool in tools}
 
             if expected_tools == actual_tools:
@@ -179,15 +187,13 @@ class SmokeTest:
             self.print_error(f"Tool execution failed: {str(e)}")
             return False
 
-    async def test_codebase_search(self) -> bool:
-        """Test the codebase_search tool."""
-        self.print_test("codebase_search Tool")
+    async def test_semantic_search(self) -> bool:
+        """Test the semantic_search tool."""
+        self.print_test("semantic_search Tool")
         try:
-            result = await self.session.call_tool("codebase_search", {
+            result = await self.session.call_tool("semantic_search", {
                 "query": "test query",
                 "data_sources": ["test-repo"],
-                "mode": "auto",
-                "description_detail": "short"
             })
 
             if result.isError:
@@ -244,11 +250,9 @@ class SmokeTest:
         self.print_test("Parameter Validation")
         try:
             # Test with invalid parameters
-            result = await self.session.call_tool("codebase_search", {
+            result = await self.session.call_tool("semantic_search", {
                 "query": "",  # Empty query should fail
                 "data_sources": ["test"],
-                "mode": "auto",
-                "description_detail": "short"
             })
 
             # Should get an error about empty query
@@ -282,7 +286,7 @@ class SmokeTest:
                 await self.test_server_connection()
                 await self.test_list_tools()
                 await self.test_get_data_sources()
-                await self.test_codebase_search()
+                await self.test_semantic_search()
                 await self.test_codebase_consultant()
                 await self.test_parameter_validation()
 

--- a/src/codealive_mcp_server.py
+++ b/src/codealive_mcp_server.py
@@ -29,6 +29,7 @@ from core import codealive_lifespan, setup_logging, setup_debug_logging, init_tr
 import core.client as _client_module  # for /ready flag access
 from middleware import N8NRemoveParametersMiddleware, ObservabilityMiddleware
 from tools import (
+    chat,
     codebase_consultant,
     codebase_search,
     fetch_artifacts,
@@ -58,13 +59,20 @@ mcp = FastMCP(
     3. To get full content:
        - For repos in your working directory: use `Read()` on the local files
        - For external repos: use `fetch_artifacts` with identifiers from search results
-    4. Use `codebase_consultant` for in-depth analysis and synthesized answers
+    4. Use `get_artifact_relationships` or `fetch_artifacts` to drill into the most relevant hits
+    5. If your environment supports subagents and you need the highest reliability or depth,
+       prefer an agentic workflow where a subagent combines `semantic_search`, `grep_search`,
+       artifact fetches, relationship inspection, and local file reads
+    6. Use `chat` only when you specifically need a synthesized answer after search;
+       it is usually not the default choice and can take up to 30 seconds
 
     For effective code exploration:
     - Start with broad natural-language queries in `semantic_search` to understand the overall structure
     - Use `grep_search(regex=false)` for exact strings and `grep_search(regex=true)` for regex patterns
     - Use specific function/class names or file path scopes when looking for particular implementations
+    - Treat `semantic_search` and `grep_search` as the default discovery tools
     - Prefer `semantic_search` over the deprecated `codebase_search` legacy alias
+    - Reserve `chat` for synthesis after search, not for first-pass evidence gathering
     - Remember that context from previous messages is maintained in the same conversation
 
     Flexible data source usage:
@@ -123,10 +131,6 @@ async def readiness_check(request: Request) -> JSONResponse:
 _READ_ONLY_TOOL = {"readOnlyHint": True}
 
 mcp.tool(
-    title="Consult Codebase",
-    annotations=_READ_ONLY_TOOL,
-)(codebase_consultant)
-mcp.tool(
     title="List Data Sources",
     annotations=_READ_ONLY_TOOL,
 )(get_data_sources)
@@ -143,6 +147,10 @@ mcp.tool(
     annotations=_READ_ONLY_TOOL,
 )(grep_search)
 mcp.tool(
+    title="Chat About Codebase",
+    annotations=_READ_ONLY_TOOL,
+)(chat)
+mcp.tool(
     title="Fetch Artifacts",
     annotations=_READ_ONLY_TOOL,
 )(fetch_artifacts)
@@ -150,6 +158,10 @@ mcp.tool(
     title="Inspect Artifact Relationships",
     annotations=_READ_ONLY_TOOL,
 )(get_artifact_relationships)
+mcp.tool(
+    title="Consult Codebase (Deprecated)",
+    annotations=_READ_ONLY_TOOL,
+)(codebase_consultant)
 
 
 def main():

--- a/src/codealive_mcp_server.py
+++ b/src/codealive_mcp_server.py
@@ -28,7 +28,15 @@ sys.path.insert(0, str(Path(__file__).parent))
 from core import codealive_lifespan, setup_logging, setup_debug_logging, init_tracing, normalize_base_url, _server_ready
 import core.client as _client_module  # for /ready flag access
 from middleware import N8NRemoveParametersMiddleware, ObservabilityMiddleware
-from tools import codebase_consultant, get_data_sources, fetch_artifacts, codebase_search, get_artifact_relationships
+from tools import (
+    codebase_consultant,
+    codebase_search,
+    fetch_artifacts,
+    get_artifact_relationships,
+    get_data_sources,
+    grep_search,
+    semantic_search,
+)
 
 # Initialize FastMCP server with lifespan and enhanced system instructions
 mcp = FastMCP(
@@ -45,19 +53,18 @@ mcp = FastMCP(
 
     When working with a codebase, follow this workflow:
     1. First use `get_data_sources` to identify available repositories and workspaces
-    2. Use `codebase_search` to find relevant files — returns paths, descriptions, and identifiers
+    2. Use `semantic_search` for natural-language retrieval by meaning
+    3. Use `grep_search` for literal string or regex matching when the pattern matters
     3. To get full content:
        - For repos in your working directory: use `Read()` on the local files
        - For external repos: use `fetch_artifacts` with identifiers from search results
     4. Use `codebase_consultant` for in-depth analysis and synthesized answers
 
     For effective code exploration:
-    - Start with broad queries to understand the overall structure
-    - Use specific function/class names when looking for particular implementations
-    - Combine natural language with code patterns in your queries
-    - Always use "auto" search mode by default; it intelligently selects the appropriate search depth
-    - IMPORTANT: Only use "deep" search mode for very complex conceptual queries as it's resource-intensive
-    - Use `description_detail="full"` in search when you need richer descriptions before fetching content
+    - Start with broad natural-language queries in `semantic_search` to understand the overall structure
+    - Use `grep_search(regex=false)` for exact strings and `grep_search(regex=true)` for regex patterns
+    - Use specific function/class names or file path scopes when looking for particular implementations
+    - Prefer `semantic_search` over the deprecated `codebase_search` legacy alias
     - Remember that context from previous messages is maintained in the same conversation
 
     Flexible data source usage:
@@ -127,6 +134,14 @@ mcp.tool(
     title="Search Codebase",
     annotations=_READ_ONLY_TOOL,
 )(codebase_search)
+mcp.tool(
+    title="Semantic Search",
+    annotations=_READ_ONLY_TOOL,
+)(semantic_search)
+mcp.tool(
+    title="Grep Search",
+    annotations=_READ_ONLY_TOOL,
+)(grep_search)
 mcp.tool(
     title="Fetch Artifacts",
     annotations=_READ_ONLY_TOOL,

--- a/src/tests/test_chat_tool.py
+++ b/src/tests/test_chat_tool.py
@@ -1,16 +1,16 @@
-"""Test suite for codebase consultant tool."""
+"""Test suite for chat tool and legacy consultant alias."""
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 import json
 from fastmcp import Context
-from tools.chat import codebase_consultant
+from tools.chat import chat, codebase_consultant
 
 
 @pytest.mark.asyncio
 @patch('tools.chat.get_api_key_from_context')
-async def test_consultant_with_simple_names(mock_get_api_key):
-    """Test codebase consultant with simple string names."""
+async def test_chat_with_simple_names(mock_get_api_key):
+    """Test chat with simple string names."""
     mock_get_api_key.return_value = "test_key"
 
     ctx = MagicMock(spec=Context)
@@ -40,7 +40,7 @@ async def test_consultant_with_simple_names(mock_get_api_key):
     ctx.request_context.lifespan_context = mock_codealive_context
 
     # Test with simple string names
-    result = await codebase_consultant(
+    result = await chat(
         ctx=ctx,
         question="Test question",
         data_sources=["repo123", "repo456"]
@@ -57,12 +57,13 @@ async def test_consultant_with_simple_names(mock_get_api_key):
     ]
 
     assert result == "Hello world"
+    assert call_args.kwargs["headers"]["X-CodeAlive-Tool"] == "chat"
 
 
 @pytest.mark.asyncio
 @patch('tools.chat.get_api_key_from_context')
-async def test_consultant_preserves_string_names(mock_get_api_key):
-    """Test codebase consultant preserves string names."""
+async def test_consultant_alias_preserves_string_names(mock_get_api_key):
+    """Test deprecated consultant alias preserves behavior."""
     mock_get_api_key.return_value = "test_key"
 
     ctx = MagicMock(spec=Context)
@@ -109,8 +110,8 @@ async def test_consultant_preserves_string_names(mock_get_api_key):
 
 @pytest.mark.asyncio
 @patch('tools.chat.get_api_key_from_context')
-async def test_consultant_with_conversation_id(mock_get_api_key):
-    """Test codebase consultant with existing conversation ID."""
+async def test_chat_with_conversation_id(mock_get_api_key):
+    """Test chat with existing conversation ID."""
     mock_get_api_key.return_value = "test_key"
 
     ctx = MagicMock(spec=Context)
@@ -134,7 +135,7 @@ async def test_consultant_with_conversation_id(mock_get_api_key):
 
     ctx.request_context.lifespan_context = mock_codealive_context
 
-    result = await codebase_consultant(
+    result = await chat(
         ctx=ctx,
         question="Follow up",
         conversation_id="conv_123"
@@ -153,7 +154,7 @@ async def test_consultant_with_conversation_id(mock_get_api_key):
 
 @pytest.mark.asyncio
 @patch('tools.chat.get_api_key_from_context')
-async def test_consultant_empty_question_validation(mock_get_api_key):
+async def test_chat_empty_question_validation(mock_get_api_key):
     """Test validation of empty question."""
     mock_get_api_key.return_value = "test_key"
 
@@ -161,11 +162,11 @@ async def test_consultant_empty_question_validation(mock_get_api_key):
     ctx.request_context.lifespan_context = MagicMock()
 
     # Test with empty question
-    result = await codebase_consultant(ctx=ctx, question="")
+    result = await chat(ctx=ctx, question="")
     assert "Error: No question provided" in result
 
     # Test with whitespace only
-    result = await codebase_consultant(ctx=ctx, question="   ")
+    result = await chat(ctx=ctx, question="   ")
     assert "Error: No question provided" in result
 
 
@@ -174,8 +175,8 @@ async def test_consultant_empty_question_validation(mock_get_api_key):
 @pytest.mark.asyncio
 @patch('tools.chat.get_api_key_from_context')
 @patch('tools.chat.handle_api_error')
-async def test_consultant_error_handling(mock_handle_error, mock_get_api_key):
-    """Test error handling in codebase consultant."""
+async def test_chat_error_handling(mock_handle_error, mock_get_api_key):
+    """Test error handling in chat."""
     mock_get_api_key.return_value = "test_key"
     mock_handle_error.return_value = "Error: Authentication failed"
 
@@ -191,7 +192,7 @@ async def test_consultant_error_handling(mock_handle_error, mock_get_api_key):
 
     ctx.request_context.lifespan_context = mock_codealive_context
 
-    result = await codebase_consultant(
+    result = await chat(
         ctx=ctx,
         question="Test",
         data_sources=["repo123"]

--- a/src/tests/test_e2e_tools.py
+++ b/src/tests/test_e2e_tools.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from core import CodeAliveContext
 from tools import (
+    chat,
     codebase_consultant,
     codebase_search,
     fetch_artifacts,
@@ -69,6 +70,7 @@ def _server(routes: dict) -> FastMCP:
     mcp.tool()(semantic_search)
     mcp.tool()(grep_search)
     mcp.tool()(fetch_artifacts)
+    mcp.tool()(chat)
     mcp.tool()(codebase_consultant)
     mcp.tool()(get_artifact_relationships)
     return mcp
@@ -464,10 +466,10 @@ class TestFetchArtifactsE2E:
 
 
 # ---------------------------------------------------------------------------
-# codebase_consultant (streaming SSE)
+# chat / codebase_consultant (streaming SSE)
 # ---------------------------------------------------------------------------
 
-class TestCodebaseConsultantE2E:
+class TestChatE2E:
     @staticmethod
     def _sse_body(chunks: list[str], conv_id: str = "conv-42", msg_id: str = "msg-1") -> str:
         """Build an SSE response body with metadata + content chunks + DONE."""
@@ -497,7 +499,7 @@ class TestCodebaseConsultantE2E:
         mcp = _server({"/api/chat/completions": handler})
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "codebase_consultant",
+                "chat",
                 {"question": "How does auth work?", "data_sources": ["backend"]},
             )
 
@@ -518,7 +520,7 @@ class TestCodebaseConsultantE2E:
         mcp = _server({"/api/chat/completions": handler})
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "codebase_consultant",
+                "chat",
                 {"question": "And the error handling?", "conversation_id": "conv-existing"},
             )
 
@@ -530,7 +532,7 @@ class TestCodebaseConsultantE2E:
         mcp = _server({})
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "codebase_consultant", {"question": ""},
+                "chat", {"question": ""},
                 raise_on_error=False,
             )
 
@@ -544,13 +546,30 @@ class TestCodebaseConsultantE2E:
         })
         async with Client(mcp) as client:
             result = await client.call_tool(
-                "codebase_consultant",
+                "chat",
                 {"question": "hello"},
                 raise_on_error=False,
             )
 
         text = _text(result)
         assert "401" in text or "auth" in text.lower()
+
+    @pytest.mark.asyncio
+    async def test_legacy_alias_still_works(self):
+        body = self._sse_body(["Legacy alias"])
+
+        def handler(req):
+            assert req.headers["X-CodeAlive-Tool"] == "codebase_consultant"
+            return httpx.Response(200, text=body, headers={"content-type": "text/event-stream"})
+
+        mcp = _server({"/api/chat/completions": handler})
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "codebase_consultant",
+                {"question": "How does auth work?", "data_sources": ["backend"]},
+            )
+
+        assert "Legacy alias" in _text(result)
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_e2e_tools.py
+++ b/src/tests/test_e2e_tools.py
@@ -23,8 +23,10 @@ from tools import (
     codebase_consultant,
     codebase_search,
     fetch_artifacts,
+    grep_search,
     get_artifact_relationships,
     get_data_sources,
+    semantic_search,
 )
 
 
@@ -64,6 +66,8 @@ def _server(routes: dict) -> FastMCP:
     mcp = FastMCP("E2E Test Server", lifespan=lifespan)
     mcp.tool()(get_data_sources)
     mcp.tool()(codebase_search)
+    mcp.tool()(semantic_search)
+    mcp.tool()(grep_search)
     mcp.tool()(fetch_artifacts)
     mcp.tool()(codebase_consultant)
     mcp.tool()(get_artifact_relationships)
@@ -262,6 +266,105 @@ class TestCodebaseSearchE2E:
         data = json.loads(text)
         assert "error" in data
         assert "404" in data["error"] or "not found" in data["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# semantic_search
+# ---------------------------------------------------------------------------
+
+class TestSemanticSearchE2E:
+    @pytest.mark.asyncio
+    async def test_success_hits_canonical_endpoint(self):
+        def handler(req):
+            assert req.url.params.get("Query") == "auth service"
+            assert req.url.params.get("MaxResults") == "7"
+            assert req.url.params.get_list("Names") == ["backend"]
+            assert req.url.params.get_list("Paths") == ["src/auth.py"]
+            assert req.url.params.get_list("Extensions") == [".py"]
+            assert req.headers["X-CodeAlive-Tool"] == "semantic_search"
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "identifier": "org/repo::src/auth.py::AuthService",
+                            "kind": "Class",
+                            "description": "Handles authentication",
+                            "contentByteSize": 4200,
+                            "location": {
+                                "path": "src/auth.py",
+                                "range": {"start": {"line": 10}, "end": {"line": 85}},
+                            },
+                        }
+                    ]
+                },
+            )
+
+        mcp = _server({"/api/search/semantic": handler})
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "semantic_search",
+                {
+                    "query": "auth service",
+                    "data_sources": ["backend"],
+                    "paths": ["src/auth.py"],
+                    "extensions": [".py"],
+                    "max_results": 7,
+                },
+            )
+
+        data = json.loads(_text(result))
+        assert data["results"][0]["path"] == "src/auth.py"
+        assert "fetch_artifacts" in data["hint"]
+
+
+# ---------------------------------------------------------------------------
+# grep_search
+# ---------------------------------------------------------------------------
+
+class TestGrepSearchE2E:
+    @pytest.mark.asyncio
+    async def test_success_hits_canonical_endpoint(self):
+        def handler(req):
+            assert req.url.params.get("Query") == "auth\\("
+            assert req.url.params.get("Regex") == "true"
+            assert req.headers["X-CodeAlive-Tool"] == "grep_search"
+            return httpx.Response(
+                200,
+                json={
+                    "results": [
+                        {
+                            "identifier": "org/repo::src/auth.py",
+                            "kind": "File",
+                            "matchCount": 2,
+                            "matches": [
+                                {
+                                    "lineNumber": 15,
+                                    "startColumn": 5,
+                                    "endColumn": 10,
+                                    "lineText": "auth(token)",
+                                }
+                            ],
+                            "location": {
+                                "path": "src/auth.py",
+                                "range": {"start": {"line": 15}, "end": {"line": 15}},
+                            },
+                        }
+                    ]
+                },
+            )
+
+        mcp = _server({"/api/search/grep": handler})
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "grep_search",
+                {"query": "auth\\(", "data_sources": ["backend"], "regex": True},
+            )
+
+        data = json.loads(_text(result))
+        assert data["results"][0]["matchCount"] == 2
+        assert data["results"][0]["matches"][0]["lineNumber"] == 15
+        assert "fetch_artifacts" in data["hint"] or "Read()" in data["hint"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_error_handling.py
+++ b/src/tests/test_error_handling.py
@@ -203,12 +203,12 @@ async def test_method_prefix_applied():
 
     result = await handle_api_error(
         ctx, _make_http_error(401), "chat",
-        method="codebase_consultant",
+        method="chat",
     )
 
-    assert result.startswith("[codebase_consultant] Error:")
+    assert result.startswith("[chat] Error:")
     logged = ctx.error.call_args[0][0]
-    assert logged.startswith("[codebase_consultant] ")
+    assert logged.startswith("[chat] ")
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/test_observability_middleware.py
+++ b/src/tests/test_observability_middleware.py
@@ -131,7 +131,7 @@ class TestFailedToolCall:
     @pytest.mark.asyncio
     async def test_span_status_error_on_failure(self, otel_setup):
         middleware = ObservabilityMiddleware()
-        context = _make_context("codebase_consultant")
+        context = _make_context("chat")
         call_next = AsyncMock(side_effect=ValueError("bad input"))
 
         with pytest.raises(ValueError):

--- a/src/tests/test_parameter_normalization.py
+++ b/src/tests/test_parameter_normalization.py
@@ -115,16 +115,23 @@ class TestNormalizeDataSourceNames:
 class TestParameterNormalizationIntegration:
     """Integration tests to ensure parameter normalization works in tool contexts."""
 
-    def test_search_tool_parameter_handling(self):
-        """Test that search tool properly normalizes various parameter formats."""
-        from tools.search import codebase_search
+    def test_semantic_search_parameter_handling(self):
+        """Test that semantic search properly normalizes various parameter formats."""
+        from tools.search import semantic_search
         import inspect
 
-        # Verify the function accepts Union[str, List[str]]
-        sig = inspect.signature(codebase_search)
+        sig = inspect.signature(semantic_search)
         data_sources_param = sig.parameters['data_sources']
 
-        # The annotation should accept both str and List[str]
+        assert 'Union' in str(data_sources_param.annotation) or 'str' in str(data_sources_param.annotation)
+
+    def test_grep_search_parameter_handling(self):
+        """Test that grep search properly normalizes various parameter formats."""
+        from tools.search import grep_search
+        import inspect
+
+        sig = inspect.signature(grep_search)
+        data_sources_param = sig.parameters['data_sources']
         assert 'Union' in str(data_sources_param.annotation) or 'str' in str(data_sources_param.annotation)
 
     def test_consultant_tool_parameter_handling(self):

--- a/src/tests/test_parameter_normalization.py
+++ b/src/tests/test_parameter_normalization.py
@@ -134,13 +134,13 @@ class TestParameterNormalizationIntegration:
         data_sources_param = sig.parameters['data_sources']
         assert 'Union' in str(data_sources_param.annotation) or 'str' in str(data_sources_param.annotation)
 
-    def test_consultant_tool_parameter_handling(self):
-        """Test that consultant tool properly normalizes various parameter formats."""
-        from tools.chat import codebase_consultant
+    def test_chat_tool_parameter_handling(self):
+        """Test that chat tool properly normalizes various parameter formats."""
+        from tools.chat import chat
         import inspect
 
         # Verify the function accepts Union[str, List[str]]
-        sig = inspect.signature(codebase_consultant)
+        sig = inspect.signature(chat)
         data_sources_param = sig.parameters['data_sources']
 
         # The annotation should accept both str and List[str]

--- a/src/tests/test_response_transformer.py
+++ b/src/tests/test_response_transformer.py
@@ -3,7 +3,10 @@
 import json
 
 import pytest
-from utils.response_transformer import transform_search_response_to_json
+from utils.response_transformer import (
+    transform_grep_response_to_json,
+    transform_search_response_to_json,
+)
 
 
 class TestJsonTransformer:
@@ -310,3 +313,34 @@ class TestJsonTransformer:
         assert second["path"] == "README.md"
         assert second["kind"] == "Chunk"
         assert second["description"] == "Search documentation section"
+
+    def test_grep_transform_preserves_match_previews(self):
+        response = {
+            "results": [
+                {
+                    "kind": "File",
+                    "identifier": "owner/repo::src/auth.py",
+                    "location": {
+                        "path": "src/auth.py",
+                        "range": {"start": {"line": 15}, "end": {"line": 15}},
+                    },
+                    "matchCount": 2,
+                    "matches": [
+                        {
+                            "lineNumber": 15,
+                            "startColumn": 5,
+                            "endColumn": 10,
+                            "lineText": "auth(token)",
+                        }
+                    ],
+                }
+            ]
+        }
+
+        result = transform_grep_response_to_json(response)
+        data = json.loads(result)
+
+        assert data["results"][0]["path"] == "src/auth.py"
+        assert data["results"][0]["matchCount"] == 2
+        assert data["results"][0]["matches"][0]["lineNumber"] == 15
+        assert "fetch_artifacts" in data["hint"] or "Read()" in data["hint"]

--- a/src/tests/test_search_tool.py
+++ b/src/tests/test_search_tool.py
@@ -1,23 +1,36 @@
-"""Test suite for search tool."""
+"""Test suite for semantic, grep, and legacy search tools."""
 
 import json
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from fastmcp import Context
-from tools.search import codebase_search
+
+from tools.search import codebase_search, grep_search, semantic_search
 
 
-@pytest.mark.asyncio
-@patch('tools.search.get_api_key_from_context')
-async def test_codebase_search_returns_compact_json(mock_get_api_key):
-    """Test that codebase_search returns a compact JSON string."""
-    mock_get_api_key.return_value = "test_key"
-
+def _build_context(mock_response):
     ctx = MagicMock(spec=Context)
     ctx.info = AsyncMock()
     ctx.warning = AsyncMock()
     ctx.error = AsyncMock()
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+
+    mock_codealive_context = MagicMock()
+    mock_codealive_context.client = mock_client
+    mock_codealive_context.base_url = "https://app.codealive.ai"
+
+    ctx.request_context.lifespan_context = mock_codealive_context
+    ctx.request_context.headers = {"authorization": "Bearer test_key"}
+    return ctx, mock_client
+
+
+@pytest.mark.asyncio
+@patch("tools.search.get_api_key_from_context")
+async def test_semantic_search_returns_compact_json(mock_get_api_key):
+    mock_get_api_key.return_value = "test_key"
 
     mock_response = MagicMock()
     mock_response.json.return_value = {
@@ -27,173 +40,153 @@ async def test_codebase_search_returns_compact_json(mock_get_api_key):
                 "identifier": "owner/repo::path/auth.py::authenticate_user",
                 "location": {
                     "path": "path/auth.py",
-                    "range": {"start": {"line": 10}, "end": {"line": 25}}
+                    "range": {"start": {"line": 10}, "end": {"line": 25}},
                 },
-                "description": "Authenticates a user with credentials"
+                "description": "Authenticates a user with credentials",
             }
         ]
     }
     mock_response.raise_for_status = MagicMock()
 
-    mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
+    ctx, mock_client = _build_context(mock_response)
 
-    mock_codealive_context = MagicMock()
-    mock_codealive_context.client = mock_client
-    mock_codealive_context.base_url = "https://app.codealive.ai"
-
-    ctx.request_context.lifespan_context = mock_codealive_context
-    ctx.request_context.headers = {"authorization": "Bearer test_key"}
-
-    result = await codebase_search(
+    result = await semantic_search(
         ctx=ctx,
         query="authenticate_user",
         data_sources=["test-name"],
-        mode="auto"
+        paths=["src/auth.py"],
+        extensions=[".py"],
+        max_results=7,
     )
 
-    assert isinstance(result, str)
     data = json.loads(result)
-    # Compact JSON: round-trips byte-for-byte through the compact serializer
-    assert result == json.dumps(data, separators=(",", ":"))
-    assert len(data["results"]) == 1
     assert data["results"][0]["path"] == "path/auth.py"
     assert data["results"][0]["identifier"] == "owner/repo::path/auth.py::authenticate_user"
 
     call_args = mock_client.get.call_args
+    assert call_args.args[0] == "/api/search/semantic"
     params = call_args.kwargs["params"]
+    assert ("Query", "authenticate_user") in params
     assert ("Names", "test-name") in params
+    assert ("Paths", "src/auth.py") in params
+    assert ("Extensions", ".py") in params
+    assert ("MaxResults", "7") in params
+    assert call_args.kwargs["headers"]["X-CodeAlive-Tool"] == "semantic_search"
 
 
 @pytest.mark.asyncio
-@patch('tools.search.get_api_key_from_context')
-async def test_codebase_search_always_sends_include_content_false(mock_get_api_key):
-    """Test that IncludeContent is always 'false' regardless of input."""
+@patch("tools.search.get_api_key_from_context")
+async def test_grep_search_returns_matches(mock_get_api_key):
     mock_get_api_key.return_value = "test_key"
 
-    ctx = MagicMock(spec=Context)
-    ctx.info = AsyncMock()
-    ctx.warning = AsyncMock()
-    ctx.error = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "results": [
+            {
+                "kind": "File",
+                "identifier": "owner/repo::path/auth.py",
+                "location": {
+                    "path": "path/auth.py",
+                    "range": {"start": {"line": 15}},
+                },
+                "matchCount": 2,
+                "matches": [
+                    {
+                        "lineNumber": 15,
+                        "startColumn": 5,
+                        "endColumn": 12,
+                        "lineText": "token = auth()",
+                    }
+                ],
+            }
+        ]
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    ctx, mock_client = _build_context(mock_response)
+
+    result = await grep_search(
+        ctx=ctx,
+        query="auth\\(",
+        data_sources=["test-name"],
+        regex=True,
+    )
+
+    data = json.loads(result)
+    assert data["results"][0]["matchCount"] == 2
+    assert data["results"][0]["matches"][0]["lineNumber"] == 15
+
+    call_args = mock_client.get.call_args
+    assert call_args.args[0] == "/api/search/grep"
+    params = call_args.kwargs["params"]
+    assert ("Regex", "true") in params
+    assert call_args.kwargs["headers"]["X-CodeAlive-Tool"] == "grep_search"
+
+
+@pytest.mark.asyncio
+@patch("tools.search.get_api_key_from_context")
+async def test_codebase_search_keeps_legacy_params(mock_get_api_key):
+    mock_get_api_key.return_value = "test_key"
 
     mock_response = MagicMock()
     mock_response.json.return_value = {"results": []}
     mock_response.raise_for_status = MagicMock()
 
-    mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
-
-    mock_codealive_context = MagicMock()
-    mock_codealive_context.client = mock_client
-    mock_codealive_context.base_url = "https://app.codealive.ai"
-
-    ctx.request_context.lifespan_context = mock_codealive_context
-    ctx.request_context.headers = {"authorization": "Bearer test_key"}
+    ctx, mock_client = _build_context(mock_response)
 
     await codebase_search(
         ctx=ctx,
         query="test",
         data_sources=["test-name"],
+        mode="deep",
+        description_detail="full",
     )
 
     call_args = mock_client.get.call_args
+    assert call_args.args[0] == "/api/search"
     params = call_args.kwargs["params"]
-    assert ("IncludeContent", "false") in params
-
-
-@pytest.mark.asyncio
-@patch('tools.search.get_api_key_from_context')
-async def test_codebase_search_description_detail_mapping(mock_get_api_key):
-    """Test that description_detail maps correctly to DescriptionDetail API param."""
-    mock_get_api_key.return_value = "test_key"
-
-    ctx = MagicMock(spec=Context)
-    ctx.info = AsyncMock()
-    ctx.warning = AsyncMock()
-    ctx.error = AsyncMock()
-
-    mock_response = MagicMock()
-    mock_response.json.return_value = {"results": []}
-    mock_response.raise_for_status = MagicMock()
-
-    mock_client = AsyncMock()
-    mock_client.get.return_value = mock_response
-
-    mock_codealive_context = MagicMock()
-    mock_codealive_context.client = mock_client
-    mock_codealive_context.base_url = "https://app.codealive.ai"
-
-    ctx.request_context.lifespan_context = mock_codealive_context
-    ctx.request_context.headers = {"authorization": "Bearer test_key"}
-
-    # Test "short" mapping
-    await codebase_search(
-        ctx=ctx,
-        query="test",
-        data_sources=["test-name"],
-        description_detail="short",
-    )
-    params = mock_client.get.call_args.kwargs["params"]
-    assert ("DescriptionDetail", "Short") in params
-
-    # Test "full" mapping
-    await codebase_search(
-        ctx=ctx,
-        query="test",
-        data_sources=["test-name"],
-        description_detail="full",
-    )
-    params = mock_client.get.call_args.kwargs["params"]
+    assert ("Mode", "deep") in params
     assert ("DescriptionDetail", "Full") in params
-
-    # Test default (invalid value falls back to "Short")
-    await codebase_search(
-        ctx=ctx,
-        query="test",
-        data_sources=["test-name"],
-        description_detail="invalid",
-    )
-    params = mock_client.get.call_args.kwargs["params"]
-    assert ("DescriptionDetail", "Short") in params
+    assert ("IncludeContent", "false") in params
+    assert call_args.kwargs["headers"]["X-CodeAlive-Tool"] == "codebase_search"
 
 
 @pytest.mark.asyncio
-async def test_codebase_search_empty_query_returns_error_string():
-    """Test that empty query returns a JSON error object."""
+async def test_semantic_search_empty_query_returns_error_string():
     ctx = MagicMock(spec=Context)
     ctx.info = AsyncMock()
     ctx.warning = AsyncMock()
     ctx.error = AsyncMock()
+    ctx.request_context.lifespan_context = MagicMock()
 
-    mock_codealive_context = MagicMock()
-    mock_codealive_context.base_url = "https://app.codealive.ai"
-    ctx.request_context.lifespan_context = mock_codealive_context
+    result = await semantic_search(ctx=ctx, query="")
 
-    result = await codebase_search(
-        ctx=ctx,
-        query="",
-        data_sources=["test-name"],
-        mode="auto"
-    )
-
-    assert isinstance(result, str)
     data = json.loads(result)
     assert "error" in data
     assert "Query cannot be empty" in data["error"]
 
 
 @pytest.mark.asyncio
-@patch('tools.search.get_api_key_from_context')
-async def test_codebase_search_api_error_returns_error_string(mock_get_api_key):
-    """Test that API errors return an error string (not dict)."""
-    import httpx
-
-    mock_get_api_key.return_value = "test_key"
-
+async def test_grep_search_invalid_max_results_returns_error_string():
     ctx = MagicMock(spec=Context)
     ctx.info = AsyncMock()
     ctx.warning = AsyncMock()
     ctx.error = AsyncMock()
+    ctx.request_context.lifespan_context = MagicMock()
+
+    result = await grep_search(ctx=ctx, query="foo", max_results=501)
+
+    data = json.loads(result)
+    assert "error" in data
+    assert "max_results" in data["error"]
+
+
+@pytest.mark.asyncio
+@patch("tools.search.get_api_key_from_context")
+async def test_codebase_search_api_error_returns_error_string(mock_get_api_key):
+    import httpx
+
+    mock_get_api_key.return_value = "test_key"
 
     mock_response = MagicMock()
     mock_response.status_code = 404
@@ -203,29 +196,19 @@ async def test_codebase_search_api_error_returns_error_string(mock_get_api_key):
         raise httpx.HTTPStatusError(
             "Not found",
             request=MagicMock(),
-            response=mock_response
+            response=mock_response,
         )
 
     mock_response.raise_for_status = raise_404
-
-    mock_client = AsyncMock()
+    ctx, mock_client = _build_context(mock_response)
     mock_client.get.return_value = mock_response
-
-    mock_codealive_context = MagicMock()
-    mock_codealive_context.client = mock_client
-    mock_codealive_context.base_url = "https://app.codealive.ai"
-
-    ctx.request_context.lifespan_context = mock_codealive_context
-    ctx.request_context.headers = {"authorization": "Bearer test_key"}
 
     result = await codebase_search(
         ctx=ctx,
         query="test query",
         data_sources=["invalid-name"],
-        mode="auto"
     )
 
-    assert isinstance(result, str)
     data = json.loads(result)
     assert "error" in data
     assert "404" in data["error"]

--- a/src/tests/test_stdio_smoke.py
+++ b/src/tests/test_stdio_smoke.py
@@ -99,6 +99,8 @@ async def test_stdio_server_lists_tools_and_uses_normalized_ready_endpoint():
                     "fetch_artifacts",
                     "get_artifact_relationships",
                     "get_data_sources",
+                    "grep_search",
+                    "semantic_search",
                 ]
 
                 result = await session.call_tool("get_data_sources", {})

--- a/src/tests/test_stdio_smoke.py
+++ b/src/tests/test_stdio_smoke.py
@@ -94,6 +94,7 @@ async def test_stdio_server_lists_tools_and_uses_normalized_ready_endpoint():
                 tools_result = await session.list_tools()
                 tool_names = sorted(tool.name for tool in tools_result.tools)
                 assert tool_names == [
+                    "chat",
                     "codebase_consultant",
                     "codebase_search",
                     "fetch_artifacts",

--- a/src/tests/test_tool_metadata.py
+++ b/src/tests/test_tool_metadata.py
@@ -17,7 +17,8 @@ async def test_all_tools_are_marked_read_only_with_titles():
         tools = await client.list_tools()
 
     expected_titles = {
-        "codebase_consultant": "Consult Codebase",
+        "chat": "Chat About Codebase",
+        "codebase_consultant": "Consult Codebase (Deprecated)",
         "get_data_sources": "List Data Sources",
         "codebase_search": "Search Codebase",
         "semantic_search": "Semantic Search",

--- a/src/tests/test_tool_metadata.py
+++ b/src/tests/test_tool_metadata.py
@@ -20,6 +20,8 @@ async def test_all_tools_are_marked_read_only_with_titles():
         "codebase_consultant": "Consult Codebase",
         "get_data_sources": "List Data Sources",
         "codebase_search": "Search Codebase",
+        "semantic_search": "Semantic Search",
+        "grep_search": "Grep Search",
         "fetch_artifacts": "Fetch Artifacts",
         "get_artifact_relationships": "Inspect Artifact Relationships",
     }

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,12 +1,13 @@
 """Tool implementations for CodeAlive MCP server."""
 
 from .artifact_relationships import get_artifact_relationships
-from .chat import codebase_consultant
+from .chat import chat, codebase_consultant
 from .datasources import get_data_sources
 from .fetch_artifacts import fetch_artifacts
 from .search import codebase_search, grep_search, semantic_search
 
 __all__ = [
+    'chat',
     'codebase_consultant',
     'get_data_sources',
     'fetch_artifacts',

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -4,6 +4,14 @@ from .artifact_relationships import get_artifact_relationships
 from .chat import codebase_consultant
 from .datasources import get_data_sources
 from .fetch_artifacts import fetch_artifacts
-from .search import codebase_search
+from .search import codebase_search, grep_search, semantic_search
 
-__all__ = ['codebase_consultant', 'get_data_sources', 'fetch_artifacts', 'codebase_search', 'get_artifact_relationships']
+__all__ = [
+    'codebase_consultant',
+    'get_data_sources',
+    'fetch_artifacts',
+    'codebase_search',
+    'semantic_search',
+    'grep_search',
+    'get_artifact_relationships',
+]

--- a/src/tools/artifact_relationships.py
+++ b/src/tools/artifact_relationships.py
@@ -41,9 +41,9 @@ async def get_artifact_relationships(
     Retrieve relationship groups for a single artifact by profile.
 
     Use this tool to explore an artifact's call graph, inheritance hierarchy,
-    or references. This is a drill-down tool — use it AFTER `codebase_search`
-    or `fetch_artifacts` when you need to understand how an artifact relates
-    to others in the codebase.
+    or references. This is a drill-down tool — use it AFTER `semantic_search`,
+    `grep_search`, legacy `codebase_search`, or `fetch_artifacts` when you need
+    to understand how an artifact relates to others in the codebase.
 
     Args:
         identifier: Fully qualified artifact identifier from search or fetch results.
@@ -120,8 +120,8 @@ async def get_artifact_relationships(
             ctx, e, "get artifact relationships", method=_TOOL_NAME,
             recovery_hints={
                 404: (
-                    "(1) verify the identifier came from a recent codebase_search or fetch_artifacts result, "
-                    "(2) call codebase_search again to get a fresh identifier — the index may have changed, "
+                    "(1) verify the identifier came from a recent semantic_search, grep_search, codebase_search, or fetch_artifacts result, "
+                    "(2) call semantic_search or grep_search again to get a fresh identifier — the index may have changed, "
                     "(3) check that the artifact is a function/class (relationships are not available for non-symbol artifacts)"
                 ),
             },

--- a/src/tools/chat.py
+++ b/src/tools/chat.py
@@ -1,4 +1,8 @@
-"""Chat completions tool implementation."""
+"""Chat completions tool implementation.
+
+The canonical MCP tool name is ``chat``. ``codebase_consultant`` remains as a
+deprecated alias for backward compatibility.
+"""
 
 import json
 from typing import Dict, List, Optional, Union
@@ -8,31 +12,36 @@ import httpx
 from fastmcp import Context
 
 from core import CodeAliveContext, get_api_key_from_context, log_api_request, log_api_response
-from utils import (
-    handle_api_error,
-    format_validation_error,
-    format_data_source_names,
-    normalize_data_source_names,
-)
+from utils import handle_api_error, format_validation_error, format_data_source_names, normalize_data_source_names
 
-# MCP tool/method name surfaced in every error/log message from this module.
-_TOOL_NAME = "codebase_consultant"
+_PRIMARY_TOOL_NAME = "chat"
+_LEGACY_TOOL_NAME = "codebase_consultant"
 
 
-async def codebase_consultant(
+async def chat(
     ctx: Context,
     question: str,
     data_sources: Optional[Union[str, List[str]]] = None,
     conversation_id: Optional[str] = None,
 ) -> str:
     """
-    Consult with an AI expert about your codebase for insights, explanations, and architectural guidance.
+    Ask CodeAlive for a synthesized answer about the indexed codebase.
+
+    This is a slower synthesis tool, not the default discovery workflow.
+    Agents should normally start with `semantic_search` and `grep_search`.
+    If the environment supports subagents and the task needs the highest
+    reliability or depth, prefer an agentic multi-step flow that uses a
+    subagent to combine `semantic_search`, `grep_search`, `fetch_artifacts`,
+    relationship inspection, and local file reads. Use `chat` only when a
+    synthesized answer is worth the extra latency and lower evidence fidelity.
+
+    `chat` can take up to 30 seconds.
 
     **PREREQUISITE**: You MUST call `get_data_sources` FIRST to discover available data source names,
     UNLESS the user has explicitly provided specific data source names OR you are continuing an
     existing conversation with a `conversation_id`.
 
-    This consultant understands your entire codebase and can help with:
+    This tool understands the indexed codebase and can help with:
     - Architecture and design decisions
     - Implementation strategies
     - Code explanations and walkthroughs
@@ -51,34 +60,74 @@ async def codebase_consultant(
                          Example: "conv_6789f123a456b789c123d456"
 
     Returns:
-        Expert analysis and explanation addressing your question.
+        Synthesized analysis and explanation addressing your question.
 
     Examples:
         1. Ask about architecture:
-           codebase_consultant(
+           chat(
              question="What's the best way to add caching to our API?",
              data_sources=["repo123"]
            )
 
         2. Understand implementation:
-           codebase_consultant(
+           chat(
              question="How do the microservices communicate?",
              data_sources=["platform", "payments"]
            )
 
         3. Continue a consultation:
-           codebase_consultant(
+           chat(
              question="What about error handling in that flow?",
              conversation_id="conv_6789f123a456b789c123d456"
            )
 
     Note:
+        - `chat` is usually not needed for simple lookups or evidence gathering
+        - Prefer `semantic_search` and `grep_search` as the default tools
         - Either conversation_id OR data_sources is typically provided
         - When creating a new conversation, data_sources is optional if your API key has exactly one assigned data source
         - When continuing a conversation, conversation_id is required to maintain context
-        - The consultant maintains full conversation history for follow-up questions
+        - The tool maintains full conversation history for follow-up questions
         - Choose workspace names for broad architectural questions or repository names for specific implementation details
     """
+    return await _chat_impl(
+        ctx,
+        question=question,
+        data_sources=data_sources,
+        conversation_id=conversation_id,
+        method_name=_PRIMARY_TOOL_NAME,
+    )
+
+
+async def codebase_consultant(
+    ctx: Context,
+    question: str,
+    data_sources: Optional[Union[str, List[str]]] = None,
+    conversation_id: Optional[str] = None,
+) -> str:
+    """Deprecated alias for `chat`.
+
+    Keep this for backward compatibility with older prompts and MCP clients.
+    New integrations should prefer `chat`, while default discovery should still
+    start with `semantic_search` and `grep_search`.
+    """
+    return await _chat_impl(
+        ctx,
+        question=question,
+        data_sources=data_sources,
+        conversation_id=conversation_id,
+        method_name=_LEGACY_TOOL_NAME,
+    )
+
+
+async def _chat_impl(
+    ctx: Context,
+    *,
+    question: str,
+    data_sources: Optional[Union[str, List[str]]],
+    conversation_id: Optional[str],
+    method_name: str,
+) -> str:
     context: CodeAliveContext = ctx.request_context.lifespan_context
 
     # Normalize data source names (handles Claude Desktop serialization issues)
@@ -86,13 +135,17 @@ async def codebase_consultant(
 
     if not question or not question.strip():
         return format_validation_error(
-            _TOOL_NAME,
-            "No question provided. Please provide a question to ask the consultant.",
+            method_name,
+            "No question provided. Please provide a question to ask the chat tool.",
         )
 
     # Validate that either conversation_id or data_sources is provided
     if not conversation_id and (not data_sources or len(data_sources) == 0):
         await ctx.info("No data sources provided. If the API key has exactly one assigned data source, that will be used as default.")
+    await ctx.info(
+        f"[{method_name}] This synthesized call can take up to 30 seconds. "
+        "Prefer semantic_search and grep_search for default discovery."
+    )
 
     # Transform simple question into message format internally
     messages = [{"role": "user", "content": question}]
@@ -119,7 +172,7 @@ async def codebase_consultant(
         headers = {
             "Authorization": f"Bearer {api_key}",
             "X-CodeAlive-Integration": "mcp",
-            "X-CodeAlive-Tool": "codebase_consultant",
+            "X-CodeAlive-Tool": method_name,
             "X-CodeAlive-Client": "fastmcp",
         }
 
@@ -179,7 +232,7 @@ async def codebase_consultant(
             # Include conversation and message IDs in streaming error response
             error_context = _format_metadata_context(conversation_metadata)
             error_msg = (
-                f"[{_TOOL_NAME}] Error during streaming: {str(streaming_error)}"
+                f"[{method_name}] Error during streaming: {str(streaming_error)}"
             )
             await ctx.error(error_msg)
             return f"{error_msg} {error_context}"
@@ -193,7 +246,7 @@ async def codebase_consultant(
 
     except (httpx.HTTPStatusError, Exception) as e:
         error_msg = await handle_api_error(
-            ctx, e, "chat completion", method=_TOOL_NAME,
+            ctx, e, "chat completion", method=method_name,
             recovery_hints={
                 404: (
                     "(1) if continuing a conversation, verify conversation_id matches one returned by an earlier call, "

--- a/src/tools/datasources.py
+++ b/src/tools/datasources.py
@@ -17,8 +17,9 @@ async def get_data_sources(ctx: Context, alive_only: bool = True) -> str:
     """
     **CALL THIS FIRST**: Gets all available data sources (repositories and workspaces) for the user's account.
 
-    This tool MUST be called BEFORE using `codebase_search` or `codebase_consultant` to discover
-    available data source names, UNLESS the user has explicitly provided data source names.
+    This tool MUST be called BEFORE using `semantic_search`, `grep_search`, or
+    `codebase_consultant` to discover available data source names, UNLESS the user
+    has explicitly provided data source names.
 
     A data source is a code repository or workspace that has been indexed by CodeAlive
     and can be used for code search and chat completions.
@@ -73,11 +74,8 @@ async def get_data_sources(ctx: Context, alive_only: bool = True) -> str:
 
         5. **Working history**: Have you been reading/editing files that align with this repo?
 
-        **Decision rule**:
-        - CURRENT repo → include_content=false in codebase_search (use Read tool for files)
-        - EXTERNAL repo → include_content=true in codebase_search (no file access)
-
-        Use the returned data source names with the codebase_search and codebase_consultant functions.
+        Use the returned data source names with `semantic_search`, `grep_search`,
+        `codebase_search` (legacy), and `codebase_consultant`.
     """
     context: CodeAliveContext = ctx.request_context.lifespan_context
 

--- a/src/tools/datasources.py
+++ b/src/tools/datasources.py
@@ -18,7 +18,7 @@ async def get_data_sources(ctx: Context, alive_only: bool = True) -> str:
     **CALL THIS FIRST**: Gets all available data sources (repositories and workspaces) for the user's account.
 
     This tool MUST be called BEFORE using `semantic_search`, `grep_search`, or
-    `codebase_consultant` to discover available data source names, UNLESS the user
+    `chat` to discover available data source names, UNLESS the user
     has explicitly provided data source names.
 
     A data source is a code repository or workspace that has been indexed by CodeAlive
@@ -75,7 +75,7 @@ async def get_data_sources(ctx: Context, alive_only: bool = True) -> str:
         5. **Working history**: Have you been reading/editing files that align with this repo?
 
         Use the returned data source names with `semantic_search`, `grep_search`,
-        `codebase_search` (legacy), and `codebase_consultant`.
+        `codebase_search` (legacy), `chat`, and `codebase_consultant` (legacy).
     """
     context: CodeAliveContext = ctx.request_context.lifespan_context
 

--- a/src/tools/fetch_artifacts.py
+++ b/src/tools/fetch_artifacts.py
@@ -20,8 +20,9 @@ async def fetch_artifacts(
     """
     Retrieve the full content of code artifacts by their identifiers.
 
-    Use this tool AFTER `codebase_search` to get the complete source code for results
-    you need to inspect. The `identifier` values come from the search results.
+    Use this tool AFTER `semantic_search`, `grep_search`, or legacy `codebase_search`
+    to get the complete source code for results you need to inspect. The `identifier`
+    values come from the search results.
 
     This is the recommended way to retrieve content for **external repositories** that
     you cannot access via local file reads. For repositories in your working directory,
@@ -29,7 +30,8 @@ async def fetch_artifacts(
 
     Args:
         identifiers: List of artifact identifiers from search results (max 20).
-                     These are the `identifier` attribute values from `codebase_search` XML results.
+                     These are the `identifier` attribute values from `semantic_search`,
+                     `grep_search`, or legacy `codebase_search` results.
 
                      Identifier format examples:
                        Symbol:  "my-org/backend::src/services/auth.py::AuthService.validate_token(token: str)"
@@ -61,7 +63,7 @@ async def fetch_artifacts(
 
     Note:
         - Maximum 20 identifiers per request to avoid excessive payloads.
-        - Identifiers must come from `codebase_search` results.
+        - Identifiers must come from `semantic_search`, `grep_search`, or legacy `codebase_search` results.
         - Relationships shown here are a **preview** (up to 3 call relationships per direction).
           To retrieve the complete list, or to explore other relationship types
           (inheritance, references), use `get_artifact_relationships`.
@@ -111,8 +113,8 @@ async def fetch_artifacts(
             ctx, e, "fetch artifacts", method=_TOOL_NAME,
             recovery_hints={
                 404: (
-                    "(1) verify the identifiers came from a recent codebase_search call (do not invent them), "
-                    "(2) re-run codebase_search to get fresh identifiers — the index may have changed, "
+                    "(1) verify the identifiers came from a recent semantic_search, grep_search, or codebase_search call (do not invent them), "
+                    "(2) re-run semantic_search or grep_search to get fresh identifiers — the index may have changed, "
                     "(3) for local repos in your working directory, use Read() on the file path instead"
                 ),
             },

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -1,22 +1,233 @@
-"""Search tool implementation."""
+"""Search tool implementations."""
 
-from typing import List, Optional, Union
+import json
+from typing import List, Optional, Sequence, Union
 from urllib.parse import urljoin
 
 import httpx
 from fastmcp import Context
 
-import json
-
 from core import CodeAliveContext, get_api_key_from_context, log_api_request, log_api_response
 from utils import (
-    transform_search_response_to_json,
     handle_api_error,
     normalize_data_source_names,
+    transform_grep_response_to_json,
+    transform_search_response_to_json,
 )
 
-# MCP tool/method name surfaced in every error/log message from this module.
-_TOOL_NAME = "codebase_search"
+
+def _normalize_optional_list(value: Optional[Union[str, List[str]]]) -> List[str]:
+    """Normalize optional string-or-list inputs while preserving ordering."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        return [stripped] if stripped else []
+    return [item for item in value if item]
+
+
+def _validate_query(query: str, tool_name: str) -> Optional[str]:
+    if query and query.strip():
+        return None
+
+    return json.dumps(
+        {
+            "error": (
+                f"[{tool_name}] Query cannot be empty. Please provide a search term, "
+                "pattern, function name, or description of the code you're looking for."
+            )
+        },
+        separators=(",", ":"),
+    )
+
+
+def _validate_max_results(max_results: Optional[int], tool_name: str) -> Optional[str]:
+    if max_results is None:
+        return None
+    if 1 <= max_results <= 500:
+        return None
+
+    return json.dumps(
+        {"error": f"[{tool_name}] max_results must be between 1 and 500."},
+        separators=(",", ":"),
+    )
+
+
+async def _perform_search_request(
+    ctx: Context,
+    *,
+    tool_name: str,
+    endpoint: str,
+    params: List[tuple[str, str]],
+    transform_response,
+    action_label: str,
+) -> str:
+    context: CodeAliveContext = ctx.request_context.lifespan_context
+    api_key = get_api_key_from_context(ctx)
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "X-CodeAlive-Integration": "mcp",
+        "X-CodeAlive-Tool": tool_name,
+        "X-CodeAlive-Client": "fastmcp",
+    }
+
+    full_url = urljoin(context.base_url, endpoint)
+    request_id = log_api_request("GET", full_url, headers, params=params)
+
+    try:
+        response = await context.client.get(endpoint, params=params, headers=headers)
+        log_api_response(response, request_id)
+        response.raise_for_status()
+        return transform_response(response.json())
+    except (httpx.HTTPStatusError, Exception) as e:
+        error_msg = await handle_api_error(
+            ctx,
+            e,
+            action_label,
+            method=tool_name,
+            recovery_hints={
+                404: (
+                    "(1) call get_data_sources to list available data source names, "
+                    "(2) check spelling and case of the names you passed in data_sources, "
+                    "(3) drop data_sources entirely to fall back to the API key's default"
+                ),
+            },
+        )
+        return json.dumps({"error": error_msg}, separators=(",", ":"))
+
+
+def _build_scope_params(
+    *,
+    query: str,
+    data_sources: Sequence[str],
+    paths: Sequence[str],
+    extensions: Sequence[str],
+    max_results: Optional[int],
+) -> List[tuple[str, str]]:
+    params: List[tuple[str, str]] = [("Query", query)]
+
+    if max_results is not None:
+        params.append(("MaxResults", str(max_results)))
+
+    for data_source in data_sources:
+        params.append(("Names", data_source))
+    for path in paths:
+        params.append(("Paths", path))
+    for extension in extensions:
+        params.append(("Extensions", extension))
+
+    return params
+
+
+async def semantic_search(
+    ctx: Context,
+    query: str,
+    data_sources: Optional[Union[str, List[str]]] = None,
+    paths: Optional[Union[str, List[str]]] = None,
+    extensions: Optional[Union[str, List[str]]] = None,
+    max_results: Optional[int] = None,
+) -> str:
+    """
+    Canonical semantic search across indexed repositories and workspaces.
+
+    Use this for natural-language exploration when you want relevant artifacts by meaning.
+    For exact or regex matching, use `grep_search` instead.
+    """
+    tool_name = "semantic_search"
+    query_error = _validate_query(query, tool_name)
+    if query_error is not None:
+        return query_error
+
+    max_results_error = _validate_max_results(max_results, tool_name)
+    if max_results_error is not None:
+        return max_results_error
+
+    data_source_names = normalize_data_source_names(data_sources)
+    normalized_paths = _normalize_optional_list(paths)
+    normalized_extensions = _normalize_optional_list(extensions)
+
+    if data_source_names:
+        await ctx.info(
+            f"Semantic search for '{query}' across {len(data_source_names)} data source(s)"
+        )
+    else:
+        await ctx.info(
+            f"Semantic search for '{query}' using the API key's default data source"
+        )
+
+    params = _build_scope_params(
+        query=query,
+        data_sources=data_source_names,
+        paths=normalized_paths,
+        extensions=normalized_extensions,
+        max_results=max_results,
+    )
+
+    return await _perform_search_request(
+        ctx,
+        tool_name=tool_name,
+        endpoint="/api/search/semantic",
+        params=params,
+        transform_response=transform_search_response_to_json,
+        action_label="semantic search",
+    )
+
+
+async def grep_search(
+    ctx: Context,
+    query: str,
+    data_sources: Optional[Union[str, List[str]]] = None,
+    paths: Optional[Union[str, List[str]]] = None,
+    extensions: Optional[Union[str, List[str]]] = None,
+    max_results: Optional[int] = None,
+    regex: bool = False,
+) -> str:
+    """
+    Canonical exact/regex search across indexed repositories and workspaces.
+
+    Use this for literal string lookup or regex matching when the pattern itself matters.
+    """
+    tool_name = "grep_search"
+    query_error = _validate_query(query, tool_name)
+    if query_error is not None:
+        return query_error
+
+    max_results_error = _validate_max_results(max_results, tool_name)
+    if max_results_error is not None:
+        return max_results_error
+
+    data_source_names = normalize_data_source_names(data_sources)
+    normalized_paths = _normalize_optional_list(paths)
+    normalized_extensions = _normalize_optional_list(extensions)
+
+    search_kind = "regex grep" if regex else "literal grep"
+    if data_source_names:
+        await ctx.info(
+            f"{search_kind.capitalize()} for '{query}' across {len(data_source_names)} data source(s)"
+        )
+    else:
+        await ctx.info(
+            f"{search_kind.capitalize()} for '{query}' using the API key's default data source"
+        )
+
+    params = _build_scope_params(
+        query=query,
+        data_sources=data_source_names,
+        paths=normalized_paths,
+        extensions=normalized_extensions,
+        max_results=max_results,
+    )
+    params.append(("Regex", "true" if regex else "false"))
+
+    return await _perform_search_request(
+        ctx,
+        tool_name=tool_name,
+        endpoint="/api/search/grep",
+        params=params,
+        transform_response=transform_grep_response_to_json,
+        action_label="grep search",
+    )
 
 
 async def codebase_search(
@@ -27,144 +238,70 @@ async def codebase_search(
     description_detail: str = "short",
 ) -> str:
     """
-    Semantic code search across indexed repositories. Returns file paths, descriptions, and identifiers.
+    Deprecated legacy semantic search tool.
 
-    **PREREQUISITE**: Call `get_data_sources` FIRST to discover data source names,
-    UNLESS the user has explicitly provided specific names (e.g., "search in my-repo").
-
-    **WORKFLOW** (search → triage → load real content):
-      1. Call `codebase_search` → returns compact JSON with paths, descriptions, identifiers
-      2. Use `description` ONLY to triage which results look relevant — it is a
-         pointer, NOT the source of truth. Do not draw conclusions from it.
-      3. For every artifact that looks relevant, load the real source:
-         - Local repos (in your working directory): use `Read()` on the file paths
-         - External repos (not locally accessible): use `fetch_artifacts` with identifiers
-         Base your understanding only on the `content` returned by step 3.
-
-    **WHEN TO USE vs local tools:**
-      USE `codebase_search`: natural-language questions, semantic exploration, cross-repo patterns
-      USE grep/find: uncommitted local changes, exact keyword match, non-indexed branches
-
-    Args:
-        query: Natural-language description of what you're looking for.
-               Examples: "What initializes the database connection?",
-                         "Where do we parse OAuth callbacks?",
-                         "user registration controller"
-
-        data_sources: Data source names to search (from `get_data_sources`).
-                      Can be workspace names or individual repository names.
-                      Example: ["enterprise-platform", "payments-team"]
-
-        mode: Search mode (case-insensitive):
-              - "auto": (Default, recommended) Adaptive semantic search.
-              - "fast": Lightweight lexical pass; for known terms/exact names.
-              - "deep": Exhaustive semantic exploration; use sparingly for hard,
-                        cross-cutting questions.
-
-        description_detail: Detail level for result descriptions (default: "short").
-                            - "short": Brief summary of each result.
-                            - "full": Richer description — use when deciding which results to fetch.
-
-    Returns:
-        Compact JSON with search results plus a `hint` field reminding the agent to
-        load real content via `fetch_artifacts`/`Read()` before drawing conclusions.
-        Each result includes path, line numbers, kind, identifier, contentByteSize,
-        and description. **`description` is a triage pointer only — never the source
-        of truth.** Use identifiers with `fetch_artifacts` to get full content for
-        external repos, or `Read()` for local files.
-
-        Shape:
-            {"results":[{"path":"...","startLine":...,"endLine":...,"kind":"...",
-                         "identifier":"...","contentByteSize":...,"description":"..."}],
-             "hint":"..."}
-
-    Note:
-        - Searches the INDEXED version of repositories, NOT local files
-        - Start with "auto" mode; escalate to "deep" only if needed
-        - Always call get_data_sources() first to get available repository names
+    Prefer `semantic_search` for new integrations. This compatibility alias keeps the
+    previous MCP contract and forwards to the legacy backend endpoint unchanged.
     """
-    context: CodeAliveContext = ctx.request_context.lifespan_context
+    tool_name = "codebase_search"
+    query_error = _validate_query(query, tool_name)
+    if query_error is not None:
+        return query_error
 
-    # Normalize data source names (handles Claude Desktop serialization issues)
+    context: CodeAliveContext = ctx.request_context.lifespan_context
     data_source_names = normalize_data_source_names(data_sources)
 
-    # Validate inputs
-    if not query or not query.strip():
-        return json.dumps(
-            {
-                "error": f"[{_TOOL_NAME}] Query cannot be empty. Please provide a search term, function name, or description of the code you're looking for."
-            },
-            separators=(",", ":"),
+    normalized_mode = mode.lower() if mode else "auto"
+    if normalized_mode not in ["auto", "fast", "deep"]:
+        await ctx.warning(
+            f"[{tool_name}] Invalid search mode: {mode}. "
+            "Valid modes are 'auto', 'fast', and 'deep'. Using 'auto' instead."
+        )
+        normalized_mode = "auto"
+
+    detail_map = {"short": "Short", "full": "Full"}
+    normalized_detail = detail_map.get((description_detail or "short").lower(), "Short")
+
+    if data_source_names:
+        await ctx.info(
+            f"Legacy codebase_search for '{query}' across {len(data_source_names)} data source(s)"
+        )
+    else:
+        await ctx.info(
+            f"Legacy codebase_search for '{query}' using the API key's default data source"
         )
 
-    if not data_source_names or len(data_source_names) == 0:
-        await ctx.info("No data source names provided. If the API key has exactly one assigned data source, that will be used as default.")
+    params = [
+        ("Query", query),
+        ("Mode", normalized_mode),
+        ("IncludeContent", "false"),
+        ("DescriptionDetail", normalized_detail),
+    ]
+    for data_source in data_source_names:
+        params.append(("Names", data_source))
+
+    api_key = get_api_key_from_context(ctx)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "X-CodeAlive-Integration": "mcp",
+        "X-CodeAlive-Tool": tool_name,
+        "X-CodeAlive-Client": "fastmcp",
+    }
+
+    full_url = urljoin(context.base_url, "/api/search")
+    request_id = log_api_request("GET", full_url, headers, params=params)
 
     try:
-        normalized_mode = mode.lower() if mode else "auto"
-
-        # Map input mode to backend's expected enum values
-        if normalized_mode not in ["auto", "fast", "deep"]:
-            await ctx.warning(f"[{_TOOL_NAME}] Invalid search mode: {mode}. Valid modes are 'auto', 'fast', and 'deep'. Using 'auto' instead.")
-            normalized_mode = "auto"
-
-        # Log the search attempt
-        if data_source_names and len(data_source_names) > 0:
-            await ctx.info(f"Searching for '{query}' in {len(data_source_names)} data source(s) using {normalized_mode} mode")
-        else:
-            await ctx.info(f"Searching for '{query}' using API key's default data source with {normalized_mode} mode")
-
-        # Map description_detail to API enum values
-        detail_map = {"short": "Short", "full": "Full"}
-        normalized_detail = detail_map.get(
-            (description_detail or "short").lower(), "Short"
-        )
-
-        # Prepare query parameters as a list of tuples to support multiple values for Names
-        params = [
-            ("Query", query),
-            ("Mode", normalized_mode),
-            ("IncludeContent", "false"),
-            ("DescriptionDetail", normalized_detail),
-        ]
-
-        if data_source_names and len(data_source_names) > 0:
-            # Add each data source name as a separate query parameter
-            for ds_name in data_source_names:
-                if ds_name:  # Skip None or empty values
-                    params.append(("Names", ds_name))
-        else:
-            await ctx.info("Using API key's default data source (if available)")
-
-        api_key = get_api_key_from_context(ctx)
-
-        headers = {
-            "Authorization": f"Bearer {api_key}",
-            "X-CodeAlive-Integration": "mcp",
-            "X-CodeAlive-Tool": "codebase_search",
-            "X-CodeAlive-Client": "fastmcp",
-        }
-
-        # Log the request
-        full_url = urljoin(context.base_url, "/api/search")
-        request_id = log_api_request("GET", full_url, headers, params=params)
-
-        # Make API request
         response = await context.client.get("/api/search", params=params, headers=headers)
-
-        # Log the response
         log_api_response(response, request_id)
-
         response.raise_for_status()
-
-        search_results = response.json()
-
-        # Return compact JSON string directly
-        return transform_search_response_to_json(search_results)
-
+        return transform_search_response_to_json(response.json())
     except (httpx.HTTPStatusError, Exception) as e:
         error_msg = await handle_api_error(
-            ctx, e, "code search", method=_TOOL_NAME,
+            ctx,
+            e,
+            "code search",
+            method=tool_name,
             recovery_hints={
                 404: (
                     "(1) call get_data_sources to list available data source names, "

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,6 +1,9 @@
 """Utility functions for CodeAlive MCP server."""
 
-from .response_transformer import transform_search_response_to_json
+from .response_transformer import (
+    transform_grep_response_to_json,
+    transform_search_response_to_json,
+)
 from .errors import (
     handle_api_error,
     format_validation_error,
@@ -9,6 +12,7 @@ from .errors import (
 )
 
 __all__ = [
+    'transform_grep_response_to_json',
     'transform_search_response_to_json',
     'handle_api_error',
     'format_validation_error',

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -10,7 +10,7 @@ errors like 401/404, burning tokens and frustrating the user. The ``Try: ...``
 hint gives the model a concrete next action instead of hallucinating one.
 
 Per-tool callers can override the default ``Try:`` text via ``recovery_hints``
-when a generic hint isn't actionable enough — e.g. a 404 from ``codebase_search``
+when a generic hint isn't actionable enough — e.g. a 404 from ``semantic_search``
 should suggest ``get_data_sources``, while a 404 from ``codebase_consultant``
 should suggest checking ``conversation_id``.
 """
@@ -92,7 +92,7 @@ _ERROR_TEMPLATES: dict[int, _ErrorTemplate] = {
         default_hint=(
             "(1) call get_data_sources to see available data source names, "
             "(2) check spelling and case, "
-            "(3) verify any identifiers were returned by a recent codebase_search"
+            "(3) verify any identifiers were returned by a recent semantic_search, grep_search, or codebase_search"
         ),
     ),
     422: _ErrorTemplate(

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -11,8 +11,8 @@ hint gives the model a concrete next action instead of hallucinating one.
 
 Per-tool callers can override the default ``Try:`` text via ``recovery_hints``
 when a generic hint isn't actionable enough — e.g. a 404 from ``semantic_search``
-should suggest ``get_data_sources``, while a 404 from ``codebase_consultant``
-should suggest checking ``conversation_id``.
+should suggest ``get_data_sources``, while a 404 from ``chat`` (or legacy
+``codebase_consultant``) should suggest checking ``conversation_id``.
 """
 
 from dataclasses import dataclass
@@ -112,7 +112,7 @@ _ERROR_TEMPLATES: dict[int, _ErrorTemplate] = {
         default_hint=(
             "(1) wait at least 30 seconds before retrying, "
             "(2) reduce request frequency if this happens repeatedly, "
-            "(3) batch related questions into a single codebase_consultant call"
+            "(3) batch related questions into a single chat call"
         ),
     ),
     500: _ErrorTemplate(
@@ -185,7 +185,7 @@ async def handle_api_error(
             ``[method]`` so failures are easy to attribute.
         recovery_hints: Optional per-tool overrides for the ``Try: ...`` text,
             keyed by HTTP status code. Use this when a generic hint isn't
-            enough — e.g. ``codebase_consultant`` overrides 404 with
+            enough — e.g. ``chat`` overrides 404 with
             ``"check the conversation_id"``.
 
     Returns:

--- a/src/utils/response_transformer.py
+++ b/src/utils/response_transformer.py
@@ -4,7 +4,7 @@ import json
 from typing import Dict, Any, List, Optional
 
 
-# Hint embedded in every codebase_search response. Tells the agent that
+# Hint embedded in every search response. Tells the agent that
 # `description` is only a pointer for triage and that the source of truth
 # is the full content returned by `fetch_artifacts` (or a local `Read()`
 # for repos in the working directory).
@@ -16,6 +16,12 @@ _SEARCH_HINT = (
     "`Read()` on the file path for repos in the local working directory. "
     "Treat only the `content` returned by `fetch_artifacts` (or `Read()`) as "
     "ground truth."
+)
+
+_GREP_HINT = (
+    "Line previews in `matches` are only search evidence. Before reasoning about "
+    "behavior, load the full source via `fetch_artifacts` for external repos or "
+    "`Read()` on the local path. Treat only the full source as ground truth."
 )
 
 
@@ -39,11 +45,57 @@ def transform_search_response_to_json(
 
     results = search_results.get("results", [])
 
+    formatted_results = _format_results(results or [])
+
+    return json.dumps(
+        {"results": formatted_results, "hint": _SEARCH_HINT},
+        separators=(",", ":"),
+    )
+
+
+def transform_grep_response_to_json(grep_results: Dict[str, Any]) -> str:
+    """Transform canonical grep response to compact JSON for LLM consumption."""
+    if not isinstance(grep_results, dict) or "results" not in grep_results:
+        return json.dumps(
+            {"results": [], "hint": _GREP_HINT}, separators=(",", ":")
+        )
+
     formatted_results: List[Dict[str, Any]] = []
-    for result in results or []:
+    for result in grep_results.get("results", []) or []:
+        kind = result.get("kind", "")
+        if kind == "Folder":
+            continue
+
+        path = _extract_path_from_result(result)
+        if not path:
+            continue
+
+        item = _build_result_dict(path, result)
+        if result.get("matchCount") is not None:
+            item["matchCount"] = result["matchCount"]
+        if result.get("matches"):
+            item["matches"] = [
+                {
+                    "lineNumber": match.get("lineNumber"),
+                    "startColumn": match.get("startColumn"),
+                    "endColumn": match.get("endColumn"),
+                    "lineText": match.get("lineText"),
+                }
+                for match in result["matches"]
+            ]
+        formatted_results.append(item)
+
+    return json.dumps(
+        {"results": formatted_results, "hint": _GREP_HINT},
+        separators=(",", ":"),
+    )
+
+
+def _format_results(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    formatted_results: List[Dict[str, Any]] = []
+    for result in results:
         kind = result.get("kind", "")
 
-        # Skip folders - they don't provide value
         if kind == "Folder":
             continue
 
@@ -53,10 +105,7 @@ def transform_search_response_to_json(
 
         formatted_results.append(_build_result_dict(path, result))
 
-    return json.dumps(
-        {"results": formatted_results, "hint": _SEARCH_HINT},
-        separators=(",", ":"),
-    )
+    return formatted_results
 
 
 def _extract_path_from_result(result: Dict) -> Optional[str]:


### PR DESCRIPTION
## Summary
- add canonical semantic_search and grep_search MCP tools while keeping codebase_search as a deprecated alias
- update response transformers, tool registration, metadata, and agent guidance for the canonical search pair
- sync relationship/fetch/data source hints with the new workflow and backward compatibility story

## Testing
- uv run --extra test pytest -q src/tests